### PR TITLE
Add OpenAI chatbot feature

### DIFF
--- a/lib/Model/chat_message.dart
+++ b/lib/Model/chat_message.dart
@@ -1,0 +1,8 @@
+class ChatMessage {
+  final String text;
+  final bool isUser;
+  final String? imagePath;
+
+  ChatMessage({required this.text, required this.isUser, this.imagePath});
+}
+

--- a/lib/bloc/chatBotBloc/chatbot_bloc.dart
+++ b/lib/bloc/chatBotBloc/chatbot_bloc.dart
@@ -1,0 +1,37 @@
+import 'dart:io';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../Model/chat_message.dart';
+import '../../config/openai/openai_service.dart';
+import 'chatbot_event.dart';
+import 'chatbot_state.dart';
+
+class ChatBotBloc extends Bloc<ChatBotEvent, ChatBotState> {
+  final OpenAIService service;
+  final List<ChatMessage> _messages = [];
+
+  ChatBotBloc(this.service) : super(ChatBotInitial()) {
+    on<SendChatMessage>(_onSendChatMessage);
+  }
+
+  Future<void> _onSendChatMessage(
+      SendChatMessage event, Emitter<ChatBotState> emit) async {
+    final userMsg = ChatMessage(
+      text: event.message,
+      isUser: true,
+      imagePath: event.image?.path,
+    );
+    _messages.add(userMsg);
+    emit(ChatBotLoading(List.from(_messages)));
+    try {
+      final response =
+          await service.sendMessage(event.message, image: event.image);
+      _messages.add(ChatMessage(text: response, isUser: false));
+      emit(ChatBotLoaded(List.from(_messages)));
+    } catch (e) {
+      emit(ChatBotError(e.toString(), List.from(_messages)));
+    }
+  }
+}
+

--- a/lib/bloc/chatBotBloc/chatbot_event.dart
+++ b/lib/bloc/chatBotBloc/chatbot_event.dart
@@ -1,0 +1,20 @@
+import 'dart:io';
+import 'package:equatable/equatable.dart';
+
+abstract class ChatBotEvent extends Equatable {
+  const ChatBotEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class SendChatMessage extends ChatBotEvent {
+  final String message;
+  final File? image;
+
+  const SendChatMessage(this.message, {this.image});
+
+  @override
+  List<Object?> get props => [message, image?.path];
+}
+

--- a/lib/bloc/chatBotBloc/chatbot_state.dart
+++ b/lib/bloc/chatBotBloc/chatbot_state.dart
@@ -1,0 +1,33 @@
+import 'package:equatable/equatable.dart';
+
+import '../../Model/chat_message.dart';
+
+abstract class ChatBotState extends Equatable {
+  final List<ChatMessage> messages;
+
+  const ChatBotState(this.messages);
+
+  @override
+  List<Object?> get props => [messages];
+}
+
+class ChatBotInitial extends ChatBotState {
+  ChatBotInitial() : super(const []);
+}
+
+class ChatBotLoading extends ChatBotState {
+  const ChatBotLoading(List<ChatMessage> messages) : super(messages);
+}
+
+class ChatBotLoaded extends ChatBotState {
+  const ChatBotLoaded(List<ChatMessage> messages) : super(messages);
+}
+
+class ChatBotError extends ChatBotState {
+  final String error;
+  const ChatBotError(this.error, List<ChatMessage> messages) : super(messages);
+
+  @override
+  List<Object?> get props => [error, ...super.props];
+}
+

--- a/lib/config/constants.dart
+++ b/lib/config/constants.dart
@@ -24,6 +24,10 @@ const String defaulIsoCountryCode = "IN";
 const String weatherBaseUrl = "https://api.openweathermap.org/data/2.5/weather";
 const String weatherKey = "7a40f5b011a04cd08fc5fd45573ac228";
 
+//=========================== OpenAI API =============================
+// Replace the key below with your actual OpenAI API key.
+const String openAIApiKey = 'YOUR_OPENAI_API_KEY';
+
 
 
 

--- a/lib/config/openai/openai_service.dart
+++ b/lib/config/openai/openai_service.dart
@@ -1,0 +1,55 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+
+import '../constants.dart';
+
+class OpenAIService {
+  final Dio _dio = Dio();
+
+  Future<String> sendMessage(String message, {File? image}) async {
+    const url = 'https://api.openai.com/v1/chat/completions';
+    final headers = {
+      'Authorization': 'Bearer $openAIApiKey',
+      'Content-Type': 'application/json',
+    };
+
+    dynamic content;
+    if (image == null) {
+      content = message;
+    } else {
+      final bytes = await image.readAsBytes();
+      final b64 = base64Encode(bytes);
+      content = [
+        {'type': 'text', 'text': message},
+        {
+          'type': 'image_url',
+          'image_url': {'url': 'data:image/png;base64,' + b64}
+        }
+      ];
+    }
+
+    final body = {
+      'model': 'gpt-4o',
+      'messages': [
+        {
+          'role': 'user',
+          'content': content,
+        }
+      ]
+    };
+
+    final response = await _dio.post(
+      url,
+      data: jsonEncode(body),
+      options: Options(headers: headers),
+    );
+
+    if (response.statusCode == 200) {
+      return response.data['choices'][0]['message']['content'] as String;
+    }
+    throw Exception('Failed to get response: ' + response.statusCode.toString());
+  }
+}
+

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,6 +15,9 @@ import 'package:hive_flutter/hive_flutter.dart';
 import '../../../l10n/app_localizations.dart';
 import 'package:newsapp/routes/app_routes.dart';
 import 'package:newsapp/screens/videoNews/videoNewsBloc/video_newsall_bloc.dart';
+import 'bloc/chatBotBloc/chatbot_bloc.dart';
+import 'config/openai/openai_service.dart';
+import 'utils/widgets/chatbot_float_button.dart';
 import 'bloc/authBloc/auth_bloc.dart';
 import 'bloc/blocRepository/weather_repo.dart';
 import 'bloc/bookmark/bookmark_article_bloc.dart';
@@ -422,6 +425,7 @@ class _MyAppState extends State<MyApp> {
         BlocProvider(create: (context) => VerifyPaymentBloc()),
         BlocProvider(create: (context) => SubscriptionCountBloc()),
         BlocProvider(create: (context) => VideoNewsBloc()),
+        BlocProvider(create: (context) => ChatBotBloc(OpenAIService())),
       ],
       child: GestureDetector(
         onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
@@ -429,22 +433,31 @@ class _MyAppState extends State<MyApp> {
           builder: (context, themeState) {
             return BlocBuilder<LanguageBloc, LanguageState>(
               builder: (context, languageState) {
-                return  MaterialApp.router(
-                    key: navigatorKey,
-                    localizationsDelegates: const [
-                      AppLocalizations.delegate,
-                      GlobalMaterialLocalizations.delegate,
-                      GlobalWidgetsLocalizations.delegate,
-                      GlobalCupertinoLocalizations.delegate,
-                    ],
-                    locale: languageState.locale,
-                    supportedLocales: supportedLocales,
-                    debugShowCheckedModeBanner: false,
-                    routerConfig: router,
-                    theme: lightMode,
-                    darkTheme: darkMode,
-                    themeMode: themeState,
-                  );
+                return Stack(
+                  children: [
+                    MaterialApp.router(
+                      key: navigatorKey,
+                      localizationsDelegates: const [
+                        AppLocalizations.delegate,
+                        GlobalMaterialLocalizations.delegate,
+                        GlobalWidgetsLocalizations.delegate,
+                        GlobalCupertinoLocalizations.delegate,
+                      ],
+                      locale: languageState.locale,
+                      supportedLocales: supportedLocales,
+                      debugShowCheckedModeBanner: false,
+                      routerConfig: router,
+                      theme: lightMode,
+                      darkTheme: darkMode,
+                      themeMode: themeState,
+                    ),
+                    const Positioned(
+                      bottom: 16,
+                      right: 16,
+                      child: ChatBotFloatButton(),
+                    ),
+                  ],
+                );
                 },
             );
           },

--- a/lib/screens/chatbot/chatbot_screen.dart
+++ b/lib/screens/chatbot/chatbot_screen.dart
@@ -1,0 +1,123 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:image_picker/image_picker.dart';
+
+import '../../Model/chat_message.dart';
+import '../../bloc/chatBotBloc/chatbot_bloc.dart';
+import '../../bloc/chatBotBloc/chatbot_event.dart';
+import '../../bloc/chatBotBloc/chatbot_state.dart';
+
+class ChatBotScreen extends StatefulWidget {
+  const ChatBotScreen({super.key});
+
+  @override
+  State<ChatBotScreen> createState() => _ChatBotScreenState();
+}
+
+class _ChatBotScreenState extends State<ChatBotScreen> {
+  final TextEditingController _controller = TextEditingController();
+  final ImagePicker _picker = ImagePicker();
+  File? _image;
+
+  Future<void> _pickImage() async {
+    final XFile? picked =
+        await _picker.pickImage(source: ImageSource.gallery, imageQuality: 50);
+    if (picked != null) {
+      setState(() {
+        _image = File(picked.path);
+      });
+    }
+  }
+
+  void _send() {
+    final text = _controller.text.trim();
+    if (text.isEmpty && _image == null) return;
+    context.read<ChatBotBloc>().add(SendChatMessage(text, image: _image));
+    _controller.clear();
+    setState(() {
+      _image = null;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Saraya Bot')),
+      body: SafeArea(
+        child: Column(
+          children: [
+            Expanded(
+              child: BlocBuilder<ChatBotBloc, ChatBotState>(
+                builder: (context, state) {
+                  final msgs = state.messages;
+                  return ListView.builder(
+                    itemCount: msgs.length,
+                    itemBuilder: (context, index) {
+                      final m = msgs[index];
+                      return Align(
+                        alignment:
+                            m.isUser ? Alignment.centerRight : Alignment.centerLeft,
+                        child: Container(
+                          margin: const EdgeInsets.all(8),
+                          padding: const EdgeInsets.all(12),
+                          decoration: BoxDecoration(
+                            color: m.isUser
+                                ? Colors.blueAccent
+                                : Colors.grey.shade300,
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              if (m.imagePath != null)
+                                Padding(
+                                  padding: const EdgeInsets.only(bottom: 8.0),
+                                  child: Image.file(File(m.imagePath!), height: 100),
+                                ),
+                              Text(
+                                m.text,
+                                style: const TextStyle(color: Colors.white),
+                              ),
+                            ],
+                          ),
+                        ),
+                      );
+                    },
+                  );
+                },
+              ),
+            ),
+            if (_image != null)
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Image.file(_image!, height: 80),
+              ),
+            Row(
+              children: [
+                IconButton(
+                  icon: const Icon(Icons.photo),
+                  onPressed: _pickImage,
+                ),
+                Expanded(
+                  child: TextField(
+                    controller: _controller,
+                    decoration: const InputDecoration(
+                      hintText: 'Ask something...',
+                    ),
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.send),
+                  onPressed: _send,
+                )
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/utils/widgets/chatbot_float_button.dart
+++ b/lib/utils/widgets/chatbot_float_button.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../bloc/chatBotBloc/chatbot_bloc.dart';
+import '../../screens/chatbot/chatbot_screen.dart';
+
+class ChatBotFloatButton extends StatelessWidget {
+  const ChatBotFloatButton({super.key});
+
+  void _openChat(BuildContext context) {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => BlocProvider.value(
+          value: context.read<ChatBotBloc>(),
+          child: const ChatBotScreen(),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FloatingActionButton(
+      onPressed: () => _openChat(context),
+      child: const Icon(Icons.chat),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- introduce constants for OpenAI API
- implement `OpenAIService` for calling GPT model
- create BLoC and models for chatbot
- add chat UI screen and floating action button
- integrate new bloc and floating button in main app

## Testing
- `flutter` not available so no tests run

------
https://chatgpt.com/codex/tasks/task_e_6872af118e44833393d036644274a5c7