### PR TITLE
Implement breaking news page

### DIFF
--- a/lib/config/api_routes.dart
+++ b/lib/config/api_routes.dart
@@ -16,6 +16,7 @@ const String favoritesAddURL = "$apiUrl/favorites/add";
 const String favoritesRemoveURL = "$apiUrl/favorites/remove";
 const String recommendationNewsURL = "$apiUrl/fetch-feeds/recommended";
 const String newsTopicUrl = "$apiUrl/fetch-feeds/topics";
+const String breakingNewsUrl = "$apiUrl/fetch-feeds/topic/12";
 const String categoryUrl = "$apiUrl/fetch-feeds/topic/";
 const String getChannelPageUrl = "$apiUrl/fetch-feeds/channels";
 const String channelPageDataUrl = "$apiUrl/fetch-feeds/channel/posts";

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -82,6 +82,8 @@ import 'bloc/userChannelFollowListBloc/user_channelfollow_bloc.dart';
 import 'bloc/verifyPaymentBloc/verify_payment_bloc.dart';
 import 'bloc/viewCountBloc/view_count_bloc.dart';
 import 'bloc/weatherBloc/weather_bloc.dart';
+import 'screens/home/BreakingNewsWidget/BreakingNewsBloc.dart';
+import 'screens/home/BreakingNewsWidget/news_repository.dart';
 
 import 'config/googleAdMob/open_ad.dart';
 import 'config/helper/helper_functions.dart';
@@ -365,6 +367,7 @@ class _MyAppState extends State<MyApp> {
         BlocProvider(create: (context) => LanguageBloc.instance),
         BlocProvider(create: (context) => AuthBloc()),
         BlocProvider(create: (context) => SliderBloc()),
+        BlocProvider(create: (context) => BreakingNewsBloc(newsRepository: NewsRepository())),
         BlocProvider(create: (context) => PopularBloc()),
         BlocProvider(create: (context) => PopularNewsAllBloc()),
         BlocProvider(create: (context) => ChannelBloc()),

--- a/lib/screens/home/BreakingNewsWidget/news_repository.dart
+++ b/lib/screens/home/BreakingNewsWidget/news_repository.dart
@@ -1,37 +1,16 @@
-import 'dart:convert';
-import 'package:http/http.dart' as http;
-
-import '../../../config/constants.dart';
+import '../../../config/api_routes.dart';
+import '../../../bloc/blocRepository/get_api_repo.dart';
 import 'news_model.dart';
 
 
 class NewsRepository {
   Future<List<NewsModel>> fetchBreakingNews() async {
-    await Future.delayed(Duration(seconds: 1)); // simulate network delay
+    final apiRepo = GetapiRepo<NewsModel>(
+      url: '$breakingNewsUrl?page=1&per_page=10',
+      fromJson: NewsModel.fromJson,
+      isToken: false,
+    );
 
-    return [
-      NewsModel(
-        id: 1,
-        title: 'ترامب مصاب بالقصور الوريدي المزمن .. ما أسبابه وأعراضه؟',
-        slug: 'fire-downtown',
-        image: 'https://www.sarayanews.com/image.php?token=9e5728b3534aada97f2ef460a76881d5&size=xxlarge&d',
-        pubDate: '2025-07-13',
-      ),
-      NewsModel(
-        id: 2,
-        title: 'الأمم المتحدة: سوريا تواجه حلقة من العنف تعرض الانتقال السياسي السلمي للخطر',
-        slug: 'highway-accident',
-        image: 'https://www.sarayanews.com/image.php?token=9595170abde268cff66e14befa6f7f0f&size=',
-        pubDate: '2025-07-13',
-      ),
-      NewsModel(
-        id: 3,
-        title: 'الأردن في مجلس الأمن: أمن سورية من أمننا والهجمات الإسرائيلية اعتداء سافر',
-        slug: 'flood-warning',
-        image: 'https://www.sarayanews.com/image.php?token=a9f40653c3ac4d0df705c77c8c370ea4&size=',
-        pubDate: '2025-07-13',
-      ),
-    ];
+    return await apiRepo.getData();
   }
-
 }

--- a/lib/screens/home/home.dart
+++ b/lib/screens/home/home.dart
@@ -63,7 +63,6 @@ import '../chatbot/chatbot_screen.dart';
 import 'BreakingNewsWidget/BreakingNewsBloc.dart';
 import 'BreakingNewsWidget/BreakingNewsEvent.dart';
 import 'BreakingNewsWidget/BreakingNewsWidget.dart';
-import 'BreakingNewsWidget/news_repository.dart';
 import 'categoryNews/category_news.dart';
 import 'stories/homepage_stories.dart';
 
@@ -102,6 +101,7 @@ class _MyHomeState extends State<MyHome> with TickerProviderStateMixin {
     _appLinksDeepLink.initDeepLinks(context);
     context.read<NewsTopicBloc>().add(FetchNewsTopic());
     context.read<NotificationBloc>().add(FetchNotification(initialValue: 1, context: context));
+    context.read<BreakingNewsBloc>().add(FetchBreakingNews(context: context));
 
     CheckInternet.initConnectivity().then((results) {
       if (mounted && results.isNotEmpty) {
@@ -164,6 +164,7 @@ class _MyHomeState extends State<MyHome> with TickerProviderStateMixin {
     context.read<NotificationBloc>().add(FetchNotification(initialValue: 1, context: context, fcmToken: _fcmToken));
     context.read<WeatherBloc>().add(FetchWeatherData(lat: latitude, lon: longitude, reFetch: true));
     context.read<StoriesBloc>().add(FetchStories(reFetch: true));
+    context.read<BreakingNewsBloc>().add(FetchBreakingNews(context: context));
     initNotification();
   }
 
@@ -233,14 +234,7 @@ class _MyHomeState extends State<MyHome> with TickerProviderStateMixin {
                       // CustomSlider(),
 
                       // SizedBox(height: 5),
-                      BlocProvider(
-                        create: (context) {
-                          final bloc = BreakingNewsBloc(newsRepository: NewsRepository());
-                          Future.microtask(() => bloc.add(FetchBreakingNews(context: context)));
-                          return bloc;
-                        },
-                        child: BreakingNewsWidget(),
-                      ),
+                      BreakingNewsWidget(),
                       PopularNews(),
                       Publisher(),
                       SizedBox(height: 10,),


### PR DESCRIPTION
## Summary
- add `breakingNewsUrl` API constant
- connect BreakingNews repository to real API
- provide `BreakingNewsBloc` globally
- update home screen to use global bloc and refresh breaking news

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aac460bd08333b3dc7c94a2ca3f5f