### PR TITLE
Implement breaking news page

### DIFF
--- a/lib/config/api_routes.dart
+++ b/lib/config/api_routes.dart
@@ -16,6 +16,7 @@ const String favoritesAddURL = "$apiUrl/favorites/add";
 const String favoritesRemoveURL = "$apiUrl/favorites/remove";
 const String recommendationNewsURL = "$apiUrl/fetch-feeds/recommended";
 const String newsTopicUrl = "$apiUrl/fetch-feeds/topics";
+const String breakingNewsUrl = "$apiUrl/fetch-feeds/topic/12";
 const String categoryUrl = "$apiUrl/fetch-feeds/topic/";
 const String getChannelPageUrl = "$apiUrl/fetch-feeds/channels";
 const String channelPageDataUrl = "$apiUrl/fetch-feeds/channel/posts";

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -82,6 +82,8 @@ import 'bloc/userChannelFollowListBloc/user_channelfollow_bloc.dart';
 import 'bloc/verifyPaymentBloc/verify_payment_bloc.dart';
 import 'bloc/viewCountBloc/view_count_bloc.dart';
 import 'bloc/weatherBloc/weather_bloc.dart';
+import 'screens/home/BreakingNewsWidget/BreakingNewsBloc.dart';
+import 'screens/home/BreakingNewsWidget/news_repository.dart';
 
 import 'config/googleAdMob/open_ad.dart';
 import 'config/helper/helper_functions.dart';
@@ -365,6 +367,7 @@ class _MyAppState extends State<MyApp> {
         BlocProvider(create: (context) => LanguageBloc.instance),
         BlocProvider(create: (context) => AuthBloc()),
         BlocProvider(create: (context) => SliderBloc()),
+        BlocProvider(create: (context) => BreakingNewsBloc(newsRepository: NewsRepository())),
         BlocProvider(create: (context) => PopularBloc()),
         BlocProvider(create: (context) => PopularNewsAllBloc()),
         BlocProvider(create: (context) => ChannelBloc()),

--- a/lib/screens/home/BreakingNewsWidget/BreakingNewsPage.dart
+++ b/lib/screens/home/BreakingNewsWidget/BreakingNewsPage.dart
@@ -5,6 +5,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:newsapp/config/colors.dart';
 import 'package:newsapp/l10n/app_localizations.dart';
 import 'package:newsapp/utils/widgets/no_internet_screen.dart';
+import '../../../utils/widgets/custome_dispay_newscard.dart';
 import '../../../config/check_internet.dart';
 import '../../../config/helper/empty_state_ui.dart';
 import '../../../config/helper/helper_functions.dart';
@@ -98,23 +99,27 @@ class _BreakingNewsPageState extends State<BreakingNewsPage> {
               return ListView.builder(
                 controller: _scrollController,
                 itemCount: state.breakingNews.length,
-                padding: const EdgeInsets.all(12),
+                padding: const EdgeInsets.symmetric(horizontal: 12),
                 itemBuilder: (context, index) {
                   final news = state.breakingNews[index];
-                  return Card(
-                    margin: const EdgeInsets.only(bottom: 12),
-                    elevation: 3,
-                    child: ListTile(
-                      contentPadding: const EdgeInsets.all(12),
-                      leading: news.image != null
-                          ? Image.network(news.image!, width: 60, height: 60, fit: BoxFit.cover)
-                          : null,
-                      title: Text(news.title ?? '', maxLines: 2, overflow: TextOverflow.ellipsis),
-                      subtitle: Text(news.pubDate ?? '', style: const TextStyle(fontSize: 12)),
-                      onTap: () {
-                        // Assuming you already have a route or navigation for the detail page
-                        Navigator.pushNamed(context, '/post/${news.slug}');
-                      },
+                  return GestureDetector(
+                    onTap: () => checkLimitAndNavigate(context, news.slug ?? ''),
+                    child: Padding(
+                      padding: const EdgeInsets.only(bottom: 12),
+                      child: DisplayPopularNews(
+                        id: news.id ?? 0,
+                        viewCount: news.viewCount ?? 0,
+                        coverImg: news.image ?? '',
+                        title: news.title ?? '',
+                        channelSlug: news.channelSlug ?? '',
+                        logo: news.channelLogo ?? '',
+                        publisher: news.channelName ?? '',
+                        time: news.pubDate ?? '',
+                        slug: news.slug ?? '',
+                        postType: news.type ?? '',
+                        videoThumb: news.videoThumb ?? '',
+                        video: news.video ?? '',
+                      ),
                     ),
                   );
                 },

--- a/lib/screens/home/BreakingNewsWidget/BreakingNewsWidget.dart
+++ b/lib/screens/home/BreakingNewsWidget/BreakingNewsWidget.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 import 'package:shimmer/shimmer.dart';
+import '../../../config/helper/helper_functions.dart';
 
 import '../../../l10n/app_localizations.dart';
 import 'BreakingNewsBloc.dart';
@@ -78,7 +79,7 @@ class BreakingNewsWidget extends StatelessWidget {
 
   Widget buildNewsCard(BuildContext context, NewsModel news) {
     return GestureDetector(
-      onTap: () => context.push('/post/${news.slug}'),
+      onTap: () => checkLimitAndNavigate(context, news.slug ?? ''),
       child: Container(
         width: 250,
         margin: const EdgeInsets.only(right: 8),
@@ -167,7 +168,7 @@ class BreakingNewsWidget extends StatelessWidget {
                     Row(
                       children: [
                         Text(
-                          'USA Today',
+                          news.channelName ?? '',
                           style: const TextStyle(fontSize: 11, color: Colors.white70),
                         ),
                       ],
@@ -175,23 +176,9 @@ class BreakingNewsWidget extends StatelessWidget {
                     Row(
                       children: [
                         Text(
-                          '4h ago',
+                          formatDate(news.pubDate ?? ''),
                           style: const TextStyle(fontSize: 11, color: Colors.white60),
                         ),
-                        const SizedBox(width: 6),
-                        const Text('•', style: TextStyle(color: Colors.white38)),
-                        const SizedBox(width: 6),
-                        Text(
-                          '5 min read',
-                          style: const TextStyle(fontSize: 11, color: Colors.white60),
-                        ),
-                        // const SizedBox(width: 6),
-                        // const Text('•', style: TextStyle(color: Colors.white38)),
-                        // const SizedBox(width: 6),
-                        // Text(
-                        //   '${news.upvotes ?? 54} upvote',
-                        //   style: const TextStyle(fontSize: 11, color: Colors.white60),
-                        // ),
                       ],
                     ),
                   ],

--- a/lib/screens/home/BreakingNewsWidget/news_model.dart
+++ b/lib/screens/home/BreakingNewsWidget/news_model.dart
@@ -4,6 +4,13 @@ class NewsModel {
   final String? slug;
   final String? image;
   final String? pubDate;
+  final String? channelName;
+  final String? channelLogo;
+  final String? channelSlug;
+  final int? viewCount;
+  final String? type;
+  final String? videoThumb;
+  final String? video;
 
   NewsModel({
     this.id,
@@ -11,6 +18,13 @@ class NewsModel {
     this.slug,
     this.image,
     this.pubDate,
+    this.channelName,
+    this.channelLogo,
+    this.channelSlug,
+    this.viewCount,
+    this.type,
+    this.videoThumb,
+    this.video,
   });
 
   factory NewsModel.fromJson(Map<String, dynamic> json) {
@@ -20,6 +34,13 @@ class NewsModel {
       slug: json['slug'] as String?,
       image: json['image'] as String?,
       pubDate: json['publish_date'] ?? json['pubdate'] ?? '',
+      channelName: json['channel_name'] as String?,
+      channelLogo: json['channel_logo'] as String?,
+      channelSlug: json['channel_slug'] as String?,
+      viewCount: json['view_count'] as int?,
+      type: json['type'] as String?,
+      videoThumb: json['video_thumb'] as String?,
+      video: json['video'] as String?,
     );
   }
 }

--- a/lib/screens/home/BreakingNewsWidget/news_repository.dart
+++ b/lib/screens/home/BreakingNewsWidget/news_repository.dart
@@ -1,37 +1,16 @@
-import 'dart:convert';
-import 'package:http/http.dart' as http;
-
-import '../../../config/constants.dart';
+import '../../../config/api_routes.dart';
+import '../../../bloc/blocRepository/get_api_repo.dart';
 import 'news_model.dart';
 
 
 class NewsRepository {
   Future<List<NewsModel>> fetchBreakingNews() async {
-    await Future.delayed(Duration(seconds: 1)); // simulate network delay
+    final apiRepo = GetapiRepo<NewsModel>(
+      url: '$breakingNewsUrl?page=1&per_page=10',
+      fromJson: NewsModel.fromJson,
+      isToken: false,
+    );
 
-    return [
-      NewsModel(
-        id: 1,
-        title: 'ترامب مصاب بالقصور الوريدي المزمن .. ما أسبابه وأعراضه؟',
-        slug: 'fire-downtown',
-        image: 'https://www.sarayanews.com/image.php?token=9e5728b3534aada97f2ef460a76881d5&size=xxlarge&d',
-        pubDate: '2025-07-13',
-      ),
-      NewsModel(
-        id: 2,
-        title: 'الأمم المتحدة: سوريا تواجه حلقة من العنف تعرض الانتقال السياسي السلمي للخطر',
-        slug: 'highway-accident',
-        image: 'https://www.sarayanews.com/image.php?token=9595170abde268cff66e14befa6f7f0f&size=',
-        pubDate: '2025-07-13',
-      ),
-      NewsModel(
-        id: 3,
-        title: 'الأردن في مجلس الأمن: أمن سورية من أمننا والهجمات الإسرائيلية اعتداء سافر',
-        slug: 'flood-warning',
-        image: 'https://www.sarayanews.com/image.php?token=a9f40653c3ac4d0df705c77c8c370ea4&size=',
-        pubDate: '2025-07-13',
-      ),
-    ];
+    return await apiRepo.getData();
   }
-
 }

--- a/lib/screens/home/home.dart
+++ b/lib/screens/home/home.dart
@@ -63,7 +63,6 @@ import '../chatbot/chatbot_screen.dart';
 import 'BreakingNewsWidget/BreakingNewsBloc.dart';
 import 'BreakingNewsWidget/BreakingNewsEvent.dart';
 import 'BreakingNewsWidget/BreakingNewsWidget.dart';
-import 'BreakingNewsWidget/news_repository.dart';
 import 'categoryNews/category_news.dart';
 import 'stories/homepage_stories.dart';
 
@@ -102,6 +101,7 @@ class _MyHomeState extends State<MyHome> with TickerProviderStateMixin {
     _appLinksDeepLink.initDeepLinks(context);
     context.read<NewsTopicBloc>().add(FetchNewsTopic());
     context.read<NotificationBloc>().add(FetchNotification(initialValue: 1, context: context));
+    context.read<BreakingNewsBloc>().add(FetchBreakingNews(context: context));
 
     CheckInternet.initConnectivity().then((results) {
       if (mounted && results.isNotEmpty) {
@@ -164,6 +164,7 @@ class _MyHomeState extends State<MyHome> with TickerProviderStateMixin {
     context.read<NotificationBloc>().add(FetchNotification(initialValue: 1, context: context, fcmToken: _fcmToken));
     context.read<WeatherBloc>().add(FetchWeatherData(lat: latitude, lon: longitude, reFetch: true));
     context.read<StoriesBloc>().add(FetchStories(reFetch: true));
+    context.read<BreakingNewsBloc>().add(FetchBreakingNews(context: context));
     initNotification();
   }
 
@@ -233,14 +234,7 @@ class _MyHomeState extends State<MyHome> with TickerProviderStateMixin {
                       // CustomSlider(),
 
                       // SizedBox(height: 5),
-                      BlocProvider(
-                        create: (context) {
-                          final bloc = BreakingNewsBloc(newsRepository: NewsRepository());
-                          Future.microtask(() => bloc.add(FetchBreakingNews(context: context)));
-                          return bloc;
-                        },
-                        child: BreakingNewsWidget(),
-                      ),
+                      BreakingNewsWidget(),
                       PopularNews(),
                       Publisher(),
                       SizedBox(height: 10,),


### PR DESCRIPTION
## Summary
- add `breakingNewsUrl` API constant
- connect BreakingNews repository to real API
- provide `BreakingNewsBloc` globally
- update home screen to use global bloc and refresh breaking news
- display breaking news items using `DisplayPopularNews` and navigate with `checkLimitAndNavigate`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aac460bd08333b3dc7c94a2ca3f5f